### PR TITLE
Changed the color of heading in About page to a different color, but will need to investigate effects of CSS module for NextJS application

### DIFF
--- a/experiment-2-website/src/app/about/about.module.css
+++ b/experiment-2-website/src/app/about/about.module.css
@@ -1,15 +1,16 @@
-.page {
-    background-color: black;
+.page{
+    box-sizing: border-box;
 }
 
 .main{
-    background-color: white;
+    background-color: linear-gradient(#272767, #FA5F55);
     color: black;
     padding: 1em 4em;
 }
 
 .main h1{
     font-size: 200%;
+    color: red;
 }
 
 .main p{


### PR DESCRIPTION
# Overview
I was able to successfully change the color of the heading of About page to a different color, but not the background color of only the About page. 

Even though the About component (responsible for About page) imports the CSS module file to style only the About page, I can't change the background color of the About page to a different color. Could it be that the background color in about.module.css file has been overwritten by the background color in another CSS module file? 